### PR TITLE
Mobile-friendly changes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,8 +1,17 @@
+// thunkable
+const addBeatToChannel = sample => (dispatch, getState) => {
+  let { subdivision } = getState().selectedQuince;
+  dispatch({
+    type: "ADD_BEAT_TO_CHANNEL",
+    payload: { sample, subdivision }
+  });
+}
+
 const addChannel = _ => ({ type: "ADD_CHANNEL" });
 
-const addStepToChannel = channelIndex => ({
+const addStepToChannel = sample => ({
   type: "ADD_STEP_TO_CHANNEL",
-  payload: channelIndex
+  payload: sample
 });
 
 const changeSubdivision = offset => ({
@@ -15,34 +24,39 @@ const changeTempo = offset => ({
   payload: offset
 });
 
-// thunkable -- references global state :/
-const cycleChannelSamples = (channelIndex, currentSample) => {
-  return (dispatch, getState) => {
-    let { samples } = getState();
-    let sample = samples[samples.indexOf(currentSample) + 1] || "kick";
-    return dispatch({
-      type: "CYCLE_CHANNEL_SAMPLES",
-      payload: {
-        channelIndex,
-        sample
-      }
-    });
-  }
+// thunkable
+// const cycleChannelSamples = (channelIndex, currentSample) => (dispatch, getState) => {
+//   let { samples } = getState();
+//   let sample = samples[samples.indexOf(currentSample) + 1] || "kick";
+//   return dispatch({
+//     type: "CYCLE_CHANNEL_SAMPLES",
+//     payload: {
+//       channelIndex,
+//       sample
+//     }
+//   });
+// }
+
+// thunkable
+const removeBeatFromChannel = sample => (dispatch, getState) => {
+  let { subdivision } = getState().selectedQuince;
+  dispatch({
+    type: "REMOVE_BEAT_FROM_CHANNEL",
+    payload: { sample, subdivision }
+  });
 }
 
-const removeChannel = channelIndex => {
-  return {
-    type: "REMOVE_CHANNEL",
-    payload: channelIndex
-  }
-}
+// const removeChannel = channelIndex => {
+//   return {
+//     type: "REMOVE_CHANNEL",
+//     payload: channelIndex
+//   }
+// }
 
-const removeStepFromChannel = channelIndex => {
-  return {
-    type: "REMOVE_STEP_FROM_CHANNEL",
-    payload: channelIndex
-  }
-}
+const removeStepFromChannel = sample => ({
+  type: "REMOVE_STEP_FROM_CHANNEL",
+  payload: sample
+})
 
 const selectDrumkit = name => ({
   type: "SELECT_DRUMKIT",
@@ -50,20 +64,18 @@ const selectDrumkit = name => ({
 });
 
 // thunkable
-const selectQuince = name => {
-  return (dispatch, getState) => {
-    let { quinces } = getState();
-    let quince = quinces[name];
-    let { defaultKit } = quince;
-    dispatch({
-      type: "SELECT_QUINCE",
-      payload: quince
-    });
-    dispatch({
-      type: "SELECT_DRUMKIT",
-      payload: defaultKit
-    });
-  }
+const selectQuince = name => (dispatch, getState) => {
+  let { quinces } = getState();
+  let quince = quinces[name];
+  let { defaultKit } = quince;
+  dispatch({
+    type: "SELECT_QUINCE",
+    payload: quince
+  });
+  dispatch({
+    type: "SELECT_DRUMKIT",
+    payload: defaultKit
+  });
 }
 
 const tick = _ => ({ type: "TICK" });
@@ -83,12 +95,14 @@ const toggleStep = (sample, stepIndex) => {
 }
 
 export {
+  addBeatToChannel,
   addChannel,
   addStepToChannel,
   changeSubdivision,
   changeTempo,
-  cycleChannelSamples,
-  removeChannel,
+  // cycleChannelSamples,
+  removeBeatFromChannel,
+  // removeChannel,
   removeStepFromChannel,
   selectDrumkit,
   selectQuince,

--- a/src/components/Channel.js
+++ b/src/components/Channel.js
@@ -1,14 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import {
+  addBeatToChannel,
   addStepToChannel,
-  cycleChannelSamples,
-  removeChannel,
+  // cycleChannelSamples,
+  // removeChannel,
+  removeBeatFromChannel,
   removeStepFromChannel,
   toggleStep
 } from '../actions';
 
 const Channel = props => {
+  // console.log("rerendering...")
   const { drum } = props;
   const theme = props.selectedDrumkit;
   const playDrums = _ => {
@@ -19,44 +22,54 @@ const Channel = props => {
   const buttonsRight = [
     { text: "+", className: `${theme}-button h-8 w-8`,      fn: _ => props.addStepToChannel(props.sample) },
     { text: "-", className: `${theme}-button h-8 w-8 ml-2`, fn: _ => props.removeStepFromChannel(props.sample) },
+    { text: "++", className: `${theme}-button h-8 w-8 ml-2`, fn: _ => props.addBeatToChannel(props.sample) },
+    { text: "--", className: `${theme}-button h-8 w-8 ml-2`, fn: _ => props.removeBeatFromChannel(props.sample) },
   ];
+  const [muted, mute] = useState(false);
 
   useEffect(_ => {
     const isActive = !!props.steps[activeStep];
-    if (props.playing && isActive) {
+    if (!muted && props.playing && isActive) {
       playDrums();
     }
   });
 
-  return (
-    <div className={ `${ theme }-b flex w-full items-start pt-1` }>
-      <div className={ `${ theme }-r pr-2 mb-1 flex w-40 h-full` }>
-        <div className="flex items-center justify-center w-28"> { props.sample } </div>
-        <button
-          className={ `${ theme }-button${ drum._muted ? "-invert" : "" } h-8 w-8 ml-auto` }
-          onClick={ _ => drum._muted ? drum.mute(false) : drum.mute(true) }
-        >
-          { drum._muted ? "." : "!" }
-        </button>
-      </div>
-      <div className="flex flex-wrap items-center px-1">
-        { props.steps.map((step, idx) => {
-          let active = props.playing && activeStep === idx;
-          return (
-            <div
-              className={ `${theme}-${active ? "active" : step ? "on" : "off" }` }
-              key={ props.sample + "-st-" + idx }
-              onClick={ _ => props.toggleStep(props.sample, idx) }
-            />
-          );
-        }) }
-      </div>
-      <div className={ `flex ml-auto pl-2 ${theme}-l` }>
-        { buttonsRight.map(({ text, className, fn })=> (
-          <div key={ `btn-${text}` } className={ className } onClick={ fn }> { text } </div>
-        ))}
-      </div>
+  const renderBeats = (
+    <div className={ `${props.small ? `${ theme }-b mt-1` : "" } flex flex-wrap items-center px-1`}>
+      { props.steps.map((step, idx) => {
+        let active = props.playing && activeStep === idx;
+        return (
+          <div
+            className={ `${theme}-${active ? "active" : step ? "on" : "off" }` }
+            key={ props.sample + "-st-" + idx }
+            onClick={ _ => props.toggleStep(props.sample, idx) }
+          />
+        );
+      }) }
     </div>
+  );
+
+  return (
+    <>
+      <div className={ `${ theme }-b flex w-full items-start pt-1 ${ props.small ? "justify-center" : "" }` }>
+        <div className={ `${ theme }-r pr-2 mb-1 flex w-40 h-full` }>
+          <div className={ `flex items-center ${ props.small ? "" : "justify-center" } w-28` }> { props.sample } </div>
+          <button
+            className={ `${ theme }-button${ drum._muted ? "-invert" : "" } h-8 w-8 ml-auto` }
+            onClick={ _ => mute(!muted) }
+          >
+            { muted ? "." : "!" }
+          </button>
+        </div>
+        { props.small || renderBeats }
+        <div className={ `flex ${ props.small ? "" : `${theme}-l ml-auto`} pl-2` }>
+          { buttonsRight.map(({ text, className, fn })=> (
+            <div key={ `btn-${text}` } className={ className } onClick={ fn }> { text } </div>
+          ))}
+        </div>
+      </div>
+      { props.small && renderBeats }
+    </>
   );
 };
 
@@ -67,9 +80,11 @@ const mapStateToProps = state => ({
 });
 
 const actions = {
+  addBeatToChannel,
   addStepToChannel,
-  cycleChannelSamples,
-  removeChannel,
+  // cycleChannelSamples,
+  // removeChannel,
+  removeBeatFromChannel,
   removeStepFromChannel,
   toggleStep
 }

--- a/src/components/Sequence.js
+++ b/src/components/Sequence.js
@@ -1,9 +1,25 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { Channel } from './';
 
 const Sequence = props => {
+
+  const smallCheck = _ => window.innerWidth < 582;
+
+  const [small, setSmall] = useState(smallCheck());
+
+  const layoutCheck = _ => {
+    const sizeChanged = smallCheck() !== small;
+    if (sizeChanged) {
+      setSmall(!small);
+    }
+  }
+
+  useEffect(_ => {
+    window.addEventListener("resize", layoutCheck);
+    return _ => window.removeEventListener("resize", layoutCheck);
+  });
 
   const renderChannels = _ => Object.entries(props.selectedQuince.channels)
     .map(([ sample, steps ]) => (
@@ -12,8 +28,9 @@ const Sequence = props => {
         drum={ props.drums[sample] }
         key={ `${sample}-channel` }
         steps={ steps }
+        small={ small }
       />
-  ))
+  ));
 
   return (
     <div className={ `${props.theme} py-2 px-2` }>

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,10 @@
   src: url(./assets/fonts/JetBrainsMono-Regular.woff) format('woff');
 }
 
+* {
+  touch-action: manipulation;
+}
+
 body {
   @apply font-mono
 }
@@ -55,7 +59,7 @@ body {
 }
 
 .Acoustic-page {
-  @apply bg-grey-200
+  @apply bg-yellow-700 md:bg-grey-200
 }
 
 .Acoustic-active {
@@ -119,7 +123,7 @@ body {
 }
 
 .Electro-page {
-  @apply bg-gray-300
+  @apply bg-gray-600 md:bg-gray-300
 }
 
 .Electro-active {

--- a/src/reducers/selectedQuinceReducer.js
+++ b/src/reducers/selectedQuinceReducer.js
@@ -10,6 +10,14 @@ export default (selectedQuince = quinces["Empty Quince"], { type, payload }) => 
           [ payload ]: [...selectedQuince.channels[ payload ], 0]
         }
       }
+    case "ADD_BEAT_TO_CHANNEL":
+      return {
+        ...selectedQuince,
+        channels: {
+          ...selectedQuince.channels,
+          [ payload.sample ]: selectedQuince.channels[ payload.sample ].concat(Array.from({ length: payload.subdivision }, _ => 0))
+        }
+      }
     case "CHANGE_SUBDIVISION":
       return {
         ...selectedQuince,
@@ -29,6 +37,14 @@ export default (selectedQuince = quinces["Empty Quince"], { type, payload }) => 
     //         : [...acc, channel]
     //     }, [])]
     //   }
+    case "REMOVE_BEAT_FROM_CHANNEL":
+      return {
+        ...selectedQuince,
+        channels: {
+          ...selectedQuince.channels,
+          [ payload.sample ]: selectedQuince.channels[ payload.sample ].slice(0, selectedQuince.channels[ payload.sample ].length - payload.subdivision)
+        }
+      }
     case "REMOVE_STEP_FROM_CHANNEL":
       return {
         ...selectedQuince,


### PR DESCRIPTION
added '++' and '--' buttons that add or subtract pads to or from a channel based on the subdivision property; made the layout a bit more responsive; added a ```touch-action: manipulation``` css property to all elements to hopefully fix the zoom-on-double-tap annoyance on mobile.